### PR TITLE
Add Znote universal app

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Ghostwriter also allows to export to different formats, using pandoc or sundown:
 
 The interface is translated to many languages, as spanish, german or portuguese. 
 
+[**Znote**](https://znote.lagrede.fr) (FREE)
+  
+Znote is a free, elegant program meant to help you write beautifully organized Markdown documents. You can organize your texts, notes, and files even better, using the simplistic left-side widget organizer for smoothly navigating different files.
+
+
 ### Linux
 
 **Retext**


### PR DESCRIPTION
Hello,
I would like to suggest adding the **Znote** application in the list of universal applications.
It's a free app, available on all platforms and stores.

Review: 
https://www.softpedia.com/get/Office-tools/Diary-Organizers-Calendar/Al-Znote.shtml

Website:
https://znote.lagrede.fr

Sincerely
@alagrede the Znote creator.